### PR TITLE
changes to adapt to Macos environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Launch the containers by running docker-compose. I preferred to do it without detached mode to see the logs while the containers are spinning up and then running.
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 Check for the logs to see if the services are running properly.
@@ -13,24 +13,24 @@ Check for the logs to see if the services are running properly.
 Next, we’re going to create the topics to receive data from the IoT sensors and store the alerts filtered by the Flink application.
 
 ```bash
-docker-compose exec kafka kafka-topics --create --topic sensors --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+docker compose exec kafka kafka-topics --create --topic sensors --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
 ```
 Followed by
 
 ```bash
-docker-compose exec kafka kafka-topics --create --topic alerts --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
+docker compose exec kafka kafka-topics --create --topic alerts --bootstrap-server localhost:9092 --partitions 1 --replication-factor 1
 ```
 
 To check if the topics were created correctly you can execute the following command
 
 ```bash
-docker-compose exec kafka kafka-topics --bootstrap-server localhost:9092 --list
+docker compose exec kafka kafka-topics --bootstrap-server localhost:9092 --list
 ```
 ## Step 3: Create Postgres table
 Login to the postgres console
 
 ```bash
-sql -h localhost -U flinkuser -d flinkdb
+psql -h localhost -U flinkuser -d flinkdb
 ```
 
 Enter the password `flinkpassword` to log into the posgres console, remember this is a local configuration so default access have been configured in the `docker-compose.yml`. Then create the table
@@ -82,7 +82,7 @@ Leave it running for the rest of the tutorial.
 We’re going to launch the Flink application from within the container, so you can monitor it from the web UI through `localhost:8081`. Run the following command from the repository root:
 
 ```bash
-docker-compose exec flink-jobmanager flink run -py /opt/flink/usr_jobs/postgres_sink.py
+docker compose exec flink-jobmanager flink run -py /opt/flink/usr_jobs/postgres_sink.py
 ```
 
 You’ll see some logging information, additionally alerts will also be displayed in the `flink-jobmanager` container logs. However, we’ll check the messages using Postgres table and reading the alerts topic, which were created on this purpose.
@@ -91,7 +91,7 @@ You’ll see some logging information, additionally alerts will also be displaye
 To read data in the alerts topic, you can execute the following command:
 
 ```bash
-docker-compose exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic alerts --from-beginning
+docker compose exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic alerts --from-beginning
 ```
 
 That will bring all the messages that the topic have received so far.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.6.1

--- a/pyflink/Dockerfile
+++ b/pyflink/Dockerfile
@@ -1,4 +1,4 @@
-FROM flink:1.18.0
+FROM flink:1.18.1
 
 # Install Python
 RUN apt-get update -y && \
@@ -15,11 +15,19 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # COPY apache-flink*.tar.gz /
 # RUN pip3 install /apache-flink-libraries*.tar.gz && pip3 install /apache-flink*.tar.gz
 
+# install Java & updates
+RUN apt-get update && \
+    apt-get install -y openjdk-21-jdk && \
+    apt-get install -y ant && \
+    apt-get clean;
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-arm64
+
 WORKDIR /opt/flink
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY download_libs.sh .
-RUN chmod +x download_libs.sh && ./download_libs.sh
+RUN chmod +x ./download_libs.sh && ./download_libs.sh
 
 COPY ./usr_jobs/ ./usr_jobs

--- a/pyflink/download_libs.sh
+++ b/pyflink/download_libs.sh
@@ -7,3 +7,4 @@ curl -o ./lib/postgresql-42.7.3.jar https://jdbc.postgresql.org/download/postgre
 curl -o ./lib/flink-sql-connector-kafka-3.1.0-1.18.jar https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/3.1.0-1.18/flink-sql-connector-kafka-3.1.0-1.18.jar
 
 echo "Libs downloaded successfully"
+echo "Libs downloaded successfully"


### PR DESCRIPTION
README.md
Fix sql to plsql
Docker-compose has been deprecated, use "docker compose" instead. [Difference between "docker compose" and "docker-compose" - Stack Overflow](https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose)

download_libs.sh
Change 0A0A to 0D0A.

dockerfile
Cannot find openjdk. Probably a problem with amd64 image. The code update the docker image and set the OpenJDK location.

docker-compose.yaml
version is obsolete.